### PR TITLE
feat: expose animation function to customize animation

### DIFF
--- a/src/Component.tsx
+++ b/src/Component.tsx
@@ -304,8 +304,17 @@ export const Sheet = defineComponent({
       <Teleport to="body">
         <Transition
           css={false}
-          onEnter={handleAnimationEnter}
-          onLeave={handleAnimationLeave}
+          onEnter={
+            props.handleAnimationEnter !== undefined ?
+              props.handleAnimationEnter :
+              handleAnimationEnter 
+              
+          }
+          onLeave={
+            props.handleAnimationLeave !== undefined ?
+              props.handleAnimationLeave :
+              handleAnimationLeave
+          }
         >
           { props.visible && (
             <SheetRenderer

--- a/src/Component.tsx
+++ b/src/Component.tsx
@@ -307,12 +307,12 @@ export const Sheet = defineComponent({
           onEnter={
             props.handleAnimationEnter === null
               ? undefined
-               : props.handleAnimationEnter || handleAnimationEnter
+              : props.handleAnimationEnter || handleAnimationEnter
           }
           onLeave={
             props.handleAnimationLeave === null
-              ? undefined :
-              props.handleAnimationLeave || handleAnimationLeave
+              ? undefined
+              : props.handleAnimationLeave || handleAnimationLeave
           }
         >
           { props.visible && (

--- a/src/Component.tsx
+++ b/src/Component.tsx
@@ -305,15 +305,14 @@ export const Sheet = defineComponent({
         <Transition
           css={false}
           onEnter={
-            props.handleAnimationEnter !== undefined ?
-              props.handleAnimationEnter :
-              handleAnimationEnter 
-              
+            props.handleAnimationEnter === null
+              ? undefined
+               : props.handleAnimationEnter || handleAnimationEnter
           }
           onLeave={
-            props.handleAnimationLeave !== undefined ?
-              props.handleAnimationLeave :
-              handleAnimationLeave
+            props.handleAnimationLeave === null
+              ? undefined :
+              props.handleAnimationLeave || handleAnimationLeave
           }
         >
           { props.visible && (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,7 +8,7 @@ const BOOL_FALSE = {
 } as const
 
 const ANIMATION_CALLBACK = {
-  type: Function as PropType<(backdrop: Element, done: () => void) => void>,
+  type: Function as PropType<((element: Element, done: () => void) => void) | null | undefined>,
   default: undefined
 } as const
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,11 @@ const BOOL_FALSE = {
   default: false,
 } as const
 
+const ANIMATION_CALLBACK = {
+  type: Function as PropType<(backdrop: Element, done: () => void) => void>,
+  default: undefined
+} as const
+
 export const SHEET_PROPS = {
   /** Minimum swipe down pixel count for sheet to close itself */
   threshold: {
@@ -21,4 +26,7 @@ export const SHEET_PROPS = {
   noClickOutside: BOOL_FALSE,
   /** Removes header section, ignores #header slot */
   noHeader: BOOL_FALSE,
+  /** Loads custom animations callback */
+  handleAnimationEnter: ANIMATION_CALLBACK,
+  handleAnimationLeave: ANIMATION_CALLBACK
 } as const

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,6 @@ export const SHEET_PROPS = {
   /** Removes header section, ignores #header slot */
   noHeader: BOOL_FALSE,
   /** Loads custom animations callback */
-  handleAnimationEnter: ANIMATION_CALLBACK,
-  handleAnimationLeave: ANIMATION_CALLBACK
+  onTransitionEnter: TRANSITION_CALLBACK,
+  onTransitionEnter: TRANSITION_CALLBACK
 } as const


### PR DESCRIPTION
Closes: #8 

I created a feature to manually pass a function to sheet component for handling enter & leave animation! if there was no prop it uses the default animation behavior so it's fully compatible with previous version.

I'd be happy if you review my codes and merge this PR