### PR TITLE
Move prevent default to touchmove

### DIFF
--- a/src/Component.tsx
+++ b/src/Component.tsx
@@ -64,10 +64,11 @@ const SheetRenderer = defineComponent({
 
       let clientY: number
 
-      if ('touches' in e)
+      if ('touches' in e) {
         clientY = e.touches[0].clientY
-      else
-        clientY = e.clientY
+        e.preventDefault()
+      }
+      else { clientY = e.clientY }
 
       if (clientY === swipeStartY.value) {
         swiping.value = false
@@ -92,13 +93,10 @@ const SheetRenderer = defineComponent({
       if (e.target instanceof HTMLElement && e.target.closest(`[${STOP_ATTR}]`))
         return
 
-      if ('touches' in e) {
+      if ('touches' in e)
         swipeStartY.value = e.touches[0].clientY
-        e.preventDefault()
-      }
-      else {
+      else
         swipeStartY.value = e.clientY
-      }
 
       swipeStarted = true
     }
@@ -152,14 +150,14 @@ const SheetRenderer = defineComponent({
       ['mouseup', handleSwipeEnd],
       ['touchend', handleSwipeEnd],
       ['touchcancel', handleSwipeEnd],
-      ['touchmove', handleSwipe],
-    ] as [keyof WindowEventMap, () => any][]
+      ['touchmove', handleSwipe, { passive: false }],
+    ] as [keyof WindowEventMap, () => any, AddEventListenerOptions?][]
 
     onMounted(() => {
       syncHeight()
 
-      for (const [name, fn] of globalEvents)
-        window.addEventListener(name, fn)
+      for (const [name, fn, options] of globalEvents)
+        window.addEventListener(name, fn, options)
     })
 
     onUnmounted(() => {


### PR DESCRIPTION
Closes: [ISSUE_LINK](https://github.com/kadiryazici/bottom-sheet-vue3/issues/10)

**`Explanation (Required):`**
  - event.preventDefault() is moved from handleSwipeStart to handleSwipe, because touchstart disabled ability to click on buttons, interactive elements etc.
  - This is achieved by maknig touchmove non passive event listener and preventing that event.